### PR TITLE
Fix tarpaulin

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,5 +16,5 @@ jobs:
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1
       with:
-        version: '0.9.0'
+        version: '0.15.0'
         args: '-- --test-threads 1'


### PR DESCRIPTION
actions-rs/tarpaulin@v0.1 is failing.

```
/home/runner/work/_temp/20e6484a-0553-4df4-9733-109af1cac96d/cargo-tarpaulin: error while loading shared libraries: libssl.so.1.0.0: cannot open shared object file: No such file or directory
```